### PR TITLE
temp wc-compiler override for `shadowrootmode` attribute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "greenwood-demo-adapter-vercel",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
         "@greenwood/cli": "~0.29.0",
@@ -3897,9 +3898,9 @@
       }
     },
     "node_modules/wc-compiler": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.9.0.tgz",
-      "integrity": "sha512-AmpkRrOVPP0SHUF/9Y9BEiHejw3K+58cjLDxj/cN3w5ptJ3ZKEICDn7v+gEmj+d7XDwwb/8PjeEzmBWjo877ew==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.10.0.tgz",
+      "integrity": "sha512-GwtQw/cgbaCedoeguMc5YlRvHujDRTfpJxgglPAVT3LuJCRGXqG3nyckuV4mvblOBAPwePuP9T5nOTxbW/ZIRA==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.7.0",
@@ -4091,7 +4092,7 @@
         "remark-rehype": "^7.0.0",
         "rollup": "^2.58.0",
         "unified": "^9.2.0",
-        "wc-compiler": "~0.9.0"
+        "wc-compiler": "~0.10.0"
       },
       "dependencies": {
         "@rollup/plugin-commonjs": {
@@ -7013,9 +7014,9 @@
       "dev": true
     },
     "wc-compiler": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.9.0.tgz",
-      "integrity": "sha512-AmpkRrOVPP0SHUF/9Y9BEiHejw3K+58cjLDxj/cN3w5ptJ3ZKEICDn7v+gEmj+d7XDwwb/8PjeEzmBWjo877ew==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.10.0.tgz",
+      "integrity": "sha512-GwtQw/cgbaCedoeguMc5YlRvHujDRTfpJxgglPAVT3LuJCRGXqG3nyckuV4mvblOBAPwePuP9T5nOTxbW/ZIRA==",
       "dev": true,
       "requires": {
         "acorn": "^8.7.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "serve": "greenwood build && greenwood serve",
     "start": "npm run serve"
   },
+  "overrides": {
+    "wc-compiler": "~0.10.0"
+  },
   "devDependencies": {
     "@greenwood/cli": "~0.29.0",
     "@greenwood/plugin-adapter-vercel": "~0.29.0",


### PR DESCRIPTION
fast tracking this change until it can come through via a formal Greenwood release
https://github.com/ProjectEvergreen/greenwood/pull/1195