### PR TITLE
use `getRootNode` API for this reference in click handler

### DIFF
--- a/src/components/card.js
+++ b/src/components/card.js
@@ -57,7 +57,7 @@ export default class Card extends HTMLElement {
         <div>
           <h3>${title}</h3>
           <img src="${thumbnail}" alt="${title}" loading="lazy" width="100%">
-          <button onclick="this.parentNode.parentNode.host.selectItem()">View Item Details</button>
+          <button onclick="this.getRootNode().host.selectItem()">View Item Details</button>
         </div>
       `;
       this.attachShadow({ mode: 'open' });


### PR DESCRIPTION
Per https://github.com/ProjectEvergreen/wcc/issues/109, updating this as we can alternatively just use `getRootNode`.

----

1. [x] We should also apply this to the Netlify demo repo - https://github.com/ProjectEvergreen/greenwood-demo-adapter-netlify/pull/17