### PR TITLE
use `DOMParser` before injecting Fragments API responses in the DOM

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -24,9 +24,13 @@
 
         globalThis.document.getElementById('load-products').addEventListener('click', async () => {
           offset = offset += page;
-          const html = await fetch(`/api/fragment?offset=${offset}&limit=10`).then(resp => resp.text());
 
-          document.getElementById('load-products-output').insertAdjacentHTML('beforeend', html);
+          const html = await fetch(`/api/fragment?offset=${offset}&limit=10`).then(resp => resp.text());
+          const fragment = new DOMParser().parseFromString(html, 'text/html', {
+            includeShadowRoots: true
+          });
+
+          document.getElementById('load-products-output').insertAdjacentHTML('beforeend', fragment.body.innerHTML);
         });
       });
     </script>

--- a/src/pages/search.html
+++ b/src/pages/search.html
@@ -15,8 +15,11 @@
               'content-type': 'application/x-www-form-urlencoded'
             })
           }).then(resp => resp.text());
+          const fragment = new DOMParser().parseFromString(html, 'text/html', {
+            includeShadowRoots: true
+          });
 
-          document.getElementById('search-products-output').innerHTML = html;
+          document.getElementById('search-products-output').innerHTML = fragment.body.innerHTML;
         });
       });
     </script>


### PR DESCRIPTION
Per https://github.com/ProjectEvergreen/wcc/issues/130, this resolves the warnings being seen in Chrome around injecting DSD from backend APIs.

![Screenshot 2024-01-03 at 12 29 30 PM](https://github.com/ProjectEvergreen/greenwood-demo-adapter-vercel/assets/895923/654d43f0-24e0-41f9-985c-0b1c32b197db)

----

1. [x] Should apply this to the Netlify demo repo as well - https://github.com/ProjectEvergreen/greenwood-demo-adapter-netlify/pull/17