### PR TITLE
feature/use a `<dialog>` element instead of an `alert` for selected item experience

### DIFF
--- a/src/components/card.js
+++ b/src/components/card.js
@@ -1,7 +1,13 @@
 export default class Card extends HTMLElement {
 
   selectItem() {
-    alert(`selected item is => ${this.getAttribute('title')}!`);
+    const itemSelectedEvent = new CustomEvent("update-modal", {
+      detail: {
+        content: `You selected the "${this.title}"`,
+      },
+    });
+
+    window.dispatchEvent(itemSelectedEvent);
   }
 
   connectedCallback() {

--- a/src/components/modal.js
+++ b/src/components/modal.js
@@ -1,0 +1,65 @@
+const template = document.createElement('template');
+
+template.innerHTML = `
+  <style>
+    dialog {
+      border: 1px solid #818181;
+      text-align: center;
+      width: 40%;
+      border-radius: 10px;
+      padding: 2rem 1rem;
+      min-height: 200px;
+      background-color: #fff;
+      overflow-x: hidden;
+    }
+    
+    h3 {
+      font-size: 1.85rem;
+    }
+    
+    button {
+      background: var(--color-accent);
+      color: var(--color-white);
+      padding: 1rem 2rem;
+      border: 0;
+      font-size: 1rem;
+      border-radius: 5px;
+      cursor: pointer;
+    }
+  </style>
+  <dialog>
+    <h3 id="content"></h3>
+    <button autofocus>Close</button>
+  </dialog>
+`;
+
+export default class Modal extends HTMLElement {
+
+  updateModal(detail) {
+    console.log(`selected item is => ${detail.content}`);
+    const modal = this.shadowRoot.querySelector('dialog');
+    
+    modal.querySelector('#content').textContent = detail.content;
+    modal.showModal();
+  }
+
+  connectedCallback() {
+    if (!this.shadowRoot) {
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
+
+    // setup event handlers for updating and closing the dialog
+    window.addEventListener('update-modal', (event) => {
+      this.updateModal(event.detail);
+    })
+
+    const modal = this.shadowRoot.querySelector('dialog');
+
+    modal.querySelector('button').addEventListener("click", () => {
+      modal.close();
+    });
+  }
+}
+
+customElements.define('app-modal', Modal);

--- a/src/components/modal.js
+++ b/src/components/modal.js
@@ -26,6 +26,12 @@ template.innerHTML = `
       border-radius: 5px;
       cursor: pointer;
     }
+
+    @media(max-width: 768px) {
+      dialog {
+        width: 80%;
+      }
+    }
   </style>
   <dialog>
     <h3 id="content"></h3>

--- a/src/templates/app.html
+++ b/src/templates/app.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro">
     <link rel="stylesheet" href="../styles/main.css">
     <script type="module" src="./components/card.js"></script>
+    <script type="module" src="./components/modal.js"></script>
   </head>
 
   <body>
@@ -36,6 +37,8 @@
     <footer>
       <a href="https://www.greenwoodjs.io/">Greenwood</a>
     </footer>
+
+    <app-modal></app-modal>
 
   </body>
 


### PR DESCRIPTION
use a [`<dialog>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) instead of an alert for selected item experience
![Screenshot 2024-01-14 at 12 22 25 PM](https://github.com/ProjectEvergreen/greenwood-demo-adapter-vercel/assets/895923/857fa23f-31c0-455b-8c8e-e25c91c1fc60)
