### PR TITLE
enhancement/upgrade to greenwood v0.29.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,17 @@
     "": {
       "name": "greenwood-demo-adapter-vercel",
       "version": "1.0.0",
-      "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
-        "@greenwood/cli": "~0.29.0",
-        "@greenwood/plugin-adapter-vercel": "~0.29.0",
+        "@greenwood/cli": "~0.29.2",
+        "@greenwood/plugin-adapter-vercel": "~0.29.2",
         "rimraf": "^5.0.0"
       }
     },
     "node_modules/@greenwood/cli": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.0.tgz",
-      "integrity": "sha512-/mqXakf4ciN7j3O7iErp5xJJaginfDlL+F7oPaGo6ndqwgkPArFCrXa/C/svbmuiaymDCDCRjaAwmzsmMhHVPA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.2.tgz",
+      "integrity": "sha512-rjJocodVI23TTS5K8ASYFSdrbldyDDQu0Xi9vkLLfzhZezmhOs55dxCpTEGAw+7O5lcq1giew74PZBpqu8Slug==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-commonjs": "^21.0.0",
@@ -43,7 +42,7 @@
         "remark-rehype": "^7.0.0",
         "rollup": "^2.58.0",
         "unified": "^9.2.0",
-        "wc-compiler": "~0.9.0"
+        "wc-compiler": "~0.10.0"
       },
       "bin": {
         "greenwood": "src/index.js"
@@ -533,9 +532,9 @@
       }
     },
     "node_modules/@greenwood/plugin-adapter-vercel": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.29.0.tgz",
-      "integrity": "sha512-SdG66AOddsZYjU/QuxodwLi/m7sSgoIWeUqyskLSEB7CCxgDDCJvVql4Vn1Z8JBfxJb+SBTc+MeLZUhiJiiclA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.29.2.tgz",
+      "integrity": "sha512-D3/pFfAGk9U7c8BZrw4tFrEMDNg3C28AQb+k4Jjiph0mTRBBn1omfgG3zaidKOSL/uoDsrRsTQA/BS0uph1HQA==",
       "dev": true,
       "peerDependencies": {
         "@greenwood/cli": "^0.28.0"
@@ -4065,9 +4064,9 @@
   },
   "dependencies": {
     "@greenwood/cli": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.0.tgz",
-      "integrity": "sha512-/mqXakf4ciN7j3O7iErp5xJJaginfDlL+F7oPaGo6ndqwgkPArFCrXa/C/svbmuiaymDCDCRjaAwmzsmMhHVPA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.29.2.tgz",
+      "integrity": "sha512-rjJocodVI23TTS5K8ASYFSdrbldyDDQu0Xi9vkLLfzhZezmhOs55dxCpTEGAw+7O5lcq1giew74PZBpqu8Slug==",
       "dev": true,
       "requires": {
         "@rollup/plugin-commonjs": "^21.0.0",
@@ -4442,9 +4441,9 @@
       }
     },
     "@greenwood/plugin-adapter-vercel": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.29.0.tgz",
-      "integrity": "sha512-SdG66AOddsZYjU/QuxodwLi/m7sSgoIWeUqyskLSEB7CCxgDDCJvVql4Vn1Z8JBfxJb+SBTc+MeLZUhiJiiclA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.29.2.tgz",
+      "integrity": "sha512-D3/pFfAGk9U7c8BZrw4tFrEMDNg3C28AQb+k4Jjiph0mTRBBn1omfgG3zaidKOSL/uoDsrRsTQA/BS0uph1HQA==",
       "dev": true
     },
     "@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -26,12 +26,9 @@
     "serve": "greenwood build && greenwood serve",
     "start": "npm run serve"
   },
-  "overrides": {
-    "wc-compiler": "~0.10.0"
-  },
   "devDependencies": {
-    "@greenwood/cli": "~0.29.0",
-    "@greenwood/plugin-adapter-vercel": "~0.29.0",
+    "@greenwood/cli": "~0.29.2",
+    "@greenwood/plugin-adapter-vercel": "~0.29.2",
     "rimraf": "^5.0.0"
   }
 }


### PR DESCRIPTION
This should pull in latest **wc-compiler** from Greenwood with [`shadowrootmode` support](https://github.com/ProjectEvergreen/greenwood/releases/tag/v0.29.2)
![Screenshot 2024-01-27 at 5 11 18 PM](https://github.com/ProjectEvergreen/greenwood-demo-adapter-vercel/assets/895923/a3103b9f-feec-436f-9fb1-18322bbe288a)
```sh
✗ npm ls wc-compiler
greenwood-demo-adapter-vercel@1.0.0 /Users/owenbuckley/Workspace/project-evergreen/greenwood-demo-adapter-vercel
└─┬ @greenwood/cli@0.29.2
  └── wc-compiler@0.10.0
```

