### PR TITLE
bug/fix usage of parseUnsafeHTML

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -26,9 +26,7 @@
           offset = offset += page;
 
           const html = await fetch(`/api/fragment?offset=${offset}&limit=10`).then(resp => resp.text());
-          const fragment = Document.parseHTMLUnsafe(html, 'text/html', {
-            includeShadowRoots: true
-          });
+          const fragment = Document.parseHTMLUnsafe(html);
 
           document.getElementById('load-products-output').insertAdjacentHTML('beforeend', fragment.body.innerHTML);
         });

--- a/src/pages/search.html
+++ b/src/pages/search.html
@@ -15,9 +15,7 @@
               'content-type': 'application/x-www-form-urlencoded'
             })
           }).then(resp => resp.text());
-          const fragment = Document.parseHTMLUnsafe(html, 'text/html', {
-            includeShadowRoots: true
-          });
+          const fragment = Document.parseHTMLUnsafe(html);
 
           document.getElementById('search-products-output').innerHTML = fragment.body.innerHTML;
         });


### PR DESCRIPTION
Noticed that `parseUnsafeHTML` was failing all of a sudden
![Screenshot 2025-01-31 at 11 46 18 AM](https://github.com/user-attachments/assets/27240d2a-ede7-4756-bde4-a8bf5522198b)
![Screenshot 2025-01-31 at 11 46 44 AM](https://github.com/user-attachments/assets/dd1331b5-36cf-4c87-913d-acc3a462af53)

----

Looks like in #28 I left the old API details in there, however current MDN docs suggest `parseUnsafeHTML` only takes one parameter, which is the HTML input.  Woops!