### PR TITLE
chore/upgrade Greenwood v0.32.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ This repo aims to demonstrate a couple of Greenwood's features ([API Routes](htt
 
 |Feature    |Greenwood |Serverless|Edge|
 |---------- |----------|----------|----|
-|API Routes |   ✅     |  ✅       | ❓ |
-|SSR Pages  |   ✅     |  ✅       | ❓ |
+|API Routes |   ✅     |  ✅      | ❓ |
+|SSR Pages  |   ✅     |  ✅      | ❓ |
 
 You can see the live demo at [https://greenwood-demo-adapter-vercel.vercel.app/](https://greenwood-demo-adapter-vercel.vercel.app/).
 
@@ -35,6 +35,8 @@ The serverless demos include the following examples:
 
 - ✅  [`/api/greeting?name{xxx}`](https://greenwood-demo-adapter-vercel.vercel.app/api/greeting) - An API that returns a JSON response and optionally uses the `name` query param for customization.  Otherwise returns a default message.
 - ✅ [`/api/fragment`](https://greenwood-demo-adapter-vercel.vercel.app/api/fragment) - An API for returning fragments of server rendered Web Components as HTML, that are then appended to the DOM.  The same card component used in SSR also runs on the client to provide interactivity, like event handling.
+- ✅ [`/api/search`](https://greenwood-demo-adapter-vercel.vercel.app/api/event) - An API for handling a search using  `request.formData()`
+- ✅ [`/api/event`](https://greenwood-demo-adapter-vercel.vercel.app/api/event) - An API for mimicking a webhook `POST` request that uses `request.json()`
 
 ### SSR Pages
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,16 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@greenwood/cli": "~0.31.0",
-        "@greenwood/plugin-adapter-vercel": "~0.31.0",
+        "@greenwood/cli": "~0.32.0-alpha.6",
+        "@greenwood/plugin-adapter-vercel": "~0.32.0-alpha.6",
         "rimraf": "^6.0.1"
       }
     },
     "node_modules/@greenwood/cli": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.31.0.tgz",
-      "integrity": "sha512-fkkN0HNHFsbafcBSGn+LfHtoy+NiApnyw+p/hushZzRLCi7XqS4DH2C/0Tr2pIABWWurm4M1o2hGy9OyHMKV1g==",
+      "version": "0.32.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.32.0-alpha.6.tgz",
+      "integrity": "sha512-ml+ytoFH/S2ynhLzl6DZscwHSrySpXnIW1f11RoYzgHYCARDR0dKHZfrqp7uXDy34DgzeqMpQ38RVchtixQbXg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "^28.0.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
@@ -41,6 +40,7 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.1",
         "rollup": "^4.26.0",
+        "sucrase": "^3.35.0",
         "unified": "^11.0.5",
         "wc-compiler": "~0.16.0"
       },
@@ -48,15 +48,14 @@
         "greenwood": "src/index.js"
       },
       "engines": {
-        "node": "^18.20.5 || ^20.10.0 || ^22.12.0"
+        "node": "^18.20.5 || ^20.18.3 || >=22.12.0"
       }
     },
     "node_modules/@greenwood/plugin-adapter-vercel": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.31.0.tgz",
-      "integrity": "sha512-WxRqiIzOxcRXyp3QnXe4JU7dmUboyLb9H+mHmhabwa9CdVRx2EAvia4KGL2dXs05yQnZ3JyBBT7By22Sne3duA==",
+      "version": "0.32.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.32.0-alpha.6.tgz",
+      "integrity": "sha512-yqQVVTj3ZJKFL2zQ0bEAMdHkW42AOdkBNVdgajVkVv4T4RHulj1rRWJIakaZ5Q0TNyTHSexOGujNCw6mNamtUg==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "@greenwood/cli": "^0.31.0"
       }
@@ -4638,9 +4637,9 @@
   },
   "dependencies": {
     "@greenwood/cli": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.31.0.tgz",
-      "integrity": "sha512-fkkN0HNHFsbafcBSGn+LfHtoy+NiApnyw+p/hushZzRLCi7XqS4DH2C/0Tr2pIABWWurm4M1o2hGy9OyHMKV1g==",
+      "version": "0.32.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.32.0-alpha.6.tgz",
+      "integrity": "sha512-ml+ytoFH/S2ynhLzl6DZscwHSrySpXnIW1f11RoYzgHYCARDR0dKHZfrqp7uXDy34DgzeqMpQ38RVchtixQbXg==",
       "dev": true,
       "requires": {
         "@rollup/plugin-commonjs": "^28.0.0",
@@ -4663,14 +4662,15 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.1",
         "rollup": "^4.26.0",
+        "sucrase": "^3.35.0",
         "unified": "^11.0.5",
         "wc-compiler": "~0.16.0"
       }
     },
     "@greenwood/plugin-adapter-vercel": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.31.0.tgz",
-      "integrity": "sha512-WxRqiIzOxcRXyp3QnXe4JU7dmUboyLb9H+mHmhabwa9CdVRx2EAvia4KGL2dXs05yQnZ3JyBBT7By22Sne3duA==",
+      "version": "0.32.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.32.0-alpha.6.tgz",
+      "integrity": "sha512-yqQVVTj3ZJKFL2zQ0bEAMdHkW42AOdkBNVdgajVkVv4T4RHulj1rRWJIakaZ5Q0TNyTHSexOGujNCw6mNamtUg==",
       "dev": true
     },
     "@isaacs/cliui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,17 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@greenwood/cli": "~0.32.0-alpha.6",
-        "@greenwood/plugin-adapter-vercel": "~0.32.0-alpha.6",
+        "@greenwood/cli": "~0.32.0",
+        "@greenwood/plugin-adapter-vercel": "~0.32.0",
         "rimraf": "^6.0.1"
       }
     },
     "node_modules/@greenwood/cli": {
-      "version": "0.32.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.32.0-alpha.6.tgz",
-      "integrity": "sha512-ml+ytoFH/S2ynhLzl6DZscwHSrySpXnIW1f11RoYzgHYCARDR0dKHZfrqp7uXDy34DgzeqMpQ38RVchtixQbXg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.32.0.tgz",
+      "integrity": "sha512-8n4ja1ZTDho29JTv+ZjCTOVlB36YT0Uo4XmN/zp/tleprE5/Y1olwWD2gi9zLMyPRIzez6X7wyNwPEj8Eu+rQA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "^28.0.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
@@ -42,7 +43,7 @@
         "rollup": "^4.26.0",
         "sucrase": "^3.35.0",
         "unified": "^11.0.5",
-        "wc-compiler": "~0.16.0"
+        "wc-compiler": "~0.17.0"
       },
       "bin": {
         "greenwood": "src/index.js"
@@ -52,12 +53,13 @@
       }
     },
     "node_modules/@greenwood/plugin-adapter-vercel": {
-      "version": "0.32.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.32.0-alpha.6.tgz",
-      "integrity": "sha512-yqQVVTj3ZJKFL2zQ0bEAMdHkW42AOdkBNVdgajVkVv4T4RHulj1rRWJIakaZ5Q0TNyTHSexOGujNCw6mNamtUg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.32.0.tgz",
+      "integrity": "sha512-fG6Xj4Nn+1a/Vlex1W3NOpw2pZXMkwPfpr7mAL93omegC4KEFYj21vNjNDXJaD40zhE6SaolqlLdRB/SLMvlcw==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
-        "@greenwood/cli": "^0.31.0"
+        "@greenwood/cli": "^0.32.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -3416,9 +3418,9 @@
       }
     },
     "node_modules/pirates": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4458,9 +4460,9 @@
       }
     },
     "node_modules/wc-compiler": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.16.0.tgz",
-      "integrity": "sha512-1UngRtP8cA8HFFR1O8JDPz7rCmdeAq5gYoEhuuwqCgnhW37QGhAkq/fuG6CKMB5D+R4zI5mzkkIHk1ZAQ41YTg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.17.0.tgz",
+      "integrity": "sha512-08d31qhYjlJiTEfTEW3kpSdcNnx0j0eGaUIA1/+oyczJCxya7+tvbQ/Tz3wbS2kzd/t8iSxNYdfhpf43o6RVuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4472,7 +4474,7 @@
         "sucrase": "^3.35.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/web-namespaces": {
@@ -4637,9 +4639,9 @@
   },
   "dependencies": {
     "@greenwood/cli": {
-      "version": "0.32.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.32.0-alpha.6.tgz",
-      "integrity": "sha512-ml+ytoFH/S2ynhLzl6DZscwHSrySpXnIW1f11RoYzgHYCARDR0dKHZfrqp7uXDy34DgzeqMpQ38RVchtixQbXg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@greenwood/cli/-/cli-0.32.0.tgz",
+      "integrity": "sha512-8n4ja1ZTDho29JTv+ZjCTOVlB36YT0Uo4XmN/zp/tleprE5/Y1olwWD2gi9zLMyPRIzez6X7wyNwPEj8Eu+rQA==",
       "dev": true,
       "requires": {
         "@rollup/plugin-commonjs": "^28.0.0",
@@ -4664,13 +4666,13 @@
         "rollup": "^4.26.0",
         "sucrase": "^3.35.0",
         "unified": "^11.0.5",
-        "wc-compiler": "~0.16.0"
+        "wc-compiler": "~0.17.0"
       }
     },
     "@greenwood/plugin-adapter-vercel": {
-      "version": "0.32.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.32.0-alpha.6.tgz",
-      "integrity": "sha512-yqQVVTj3ZJKFL2zQ0bEAMdHkW42AOdkBNVdgajVkVv4T4RHulj1rRWJIakaZ5Q0TNyTHSexOGujNCw6mNamtUg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@greenwood/plugin-adapter-vercel/-/plugin-adapter-vercel-0.32.0.tgz",
+      "integrity": "sha512-fG6Xj4Nn+1a/Vlex1W3NOpw2pZXMkwPfpr7mAL93omegC4KEFYj21vNjNDXJaD40zhE6SaolqlLdRB/SLMvlcw==",
       "dev": true
     },
     "@isaacs/cliui": {
@@ -7097,9 +7099,9 @@
       "dev": true
     },
     "pirates": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "dev": true
     },
     "process-nextick-args": {
@@ -7859,9 +7861,9 @@
       }
     },
     "wc-compiler": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.16.0.tgz",
-      "integrity": "sha512-1UngRtP8cA8HFFR1O8JDPz7rCmdeAq5gYoEhuuwqCgnhW37QGhAkq/fuG6CKMB5D+R4zI5mzkkIHk1ZAQ41YTg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/wc-compiler/-/wc-compiler-0.17.0.tgz",
+      "integrity": "sha512-08d31qhYjlJiTEfTEW3kpSdcNnx0j0eGaUIA1/+oyczJCxya7+tvbQ/Tz3wbS2kzd/t8iSxNYdfhpf43o6RVuA==",
       "dev": true,
       "requires": {
         "@projectevergreen/acorn-jsx-esm": "~0.1.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "start": "npm run serve"
   },
   "devDependencies": {
-    "@greenwood/cli": "~0.31.0",
-    "@greenwood/plugin-adapter-vercel": "~0.31.0",
+    "@greenwood/cli": "~0.32.0-alpha.6",
+    "@greenwood/plugin-adapter-vercel": "~0.32.0-alpha.6",
     "rimraf": "^6.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "start": "npm run serve"
   },
   "devDependencies": {
-    "@greenwood/cli": "~0.32.0-alpha.6",
-    "@greenwood/plugin-adapter-vercel": "~0.32.0-alpha.6",
+    "@greenwood/cli": "~0.32.0",
+    "@greenwood/plugin-adapter-vercel": "~0.32.0",
     "rimraf": "^6.0.1"
   }
 }

--- a/src/layouts/app.html
+++ b/src/layouts/app.html
@@ -20,7 +20,8 @@
         <ul>
           <li><a href="/">Home</a> | </li>
           <li><a href="/products/">Products</a> | </li>
-          <li><a href="/search/">Search</a></li>
+          <li><a href="/search/">Search</a> | </li>
+          <li><a href="/admin/">Admin</a></li>
         </ul>
       </nav>
     </header>

--- a/src/pages/admin.html
+++ b/src/pages/admin.html
@@ -17,7 +17,7 @@
             })
           }).then(resp => resp.json());
 
-          document.getElementById('test-webhook=output').innerHTML = data.message;
+          document.getElementById('test-webhook-output').innerHTML = data.message;
         });
       });
     </script>
@@ -26,9 +26,9 @@
   <body>
     <article>
       <h2>Webhook API</h2>
-      <p>This is an example of a Greenwood API leveraging <code>Request.json</code> to mimic a webhook handler. You can see it fire in the network tab as <i>/api/webhooks/event</i></p>
+      <p>This is an example of a Greenwood API leveraging <code>Request.json</code> to mimic a webhook handler. You can see it fire in the network tab as <i>/api/event</i></p>
       <button id="test-webhook">Test Webhook</button>
-      <div id="test-webhook=output" aria-live="polite"></div>
+      <div id="test-webhook-output" aria-live="polite"></div>
     </article>
   </body>
 </html>

--- a/src/pages/admin.html
+++ b/src/pages/admin.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <!-- Search API Setup -->
+    <script>
+      globalThis.addEventListener('DOMContentLoaded', () => {
+        globalThis.document.querySelector('button').addEventListener('click', async (e) => {
+          e.preventDefault();
+
+          const data = await fetch('/api/event', {
+            method: 'POST',
+            body: JSON.stringify({
+              name: "Test Event",
+              time: new Date().getTime()
+            }),
+            headers: new Headers({
+              'content-type': 'application/json'
+            })
+          }).then(resp => resp.json());
+
+          document.getElementById('test-webhook=output').innerHTML = data.message;
+        });
+      });
+    </script>
+  </head>
+
+  <body>
+    <article>
+      <h2>Webhook API</h2>
+      <p>This is an example of a Greenwood API leveraging <code>Request.json</code> to mimic a webhook handler. You can see it fire in the network tab as <i>/api/webhooks/event</i></p>
+      <button id="test-webhook">Test Webhook</button>
+      <div id="test-webhook=output" aria-live="polite"></div>
+    </article>
+  </body>
+</html>

--- a/src/pages/api/event.js
+++ b/src/pages/api/event.js
@@ -1,0 +1,11 @@
+export async function handler(request) {
+  const data = await request.json();
+  const now = new Date().getTime();
+  const message = `Webhook "${data.name}" sent at "${data.time}" was successfully processed at "${now}".  Thank you!`;
+
+  return new Response(JSON.stringify({ message }), { 
+    headers: {
+      "Content-Type": "application/json"
+    }
+  })
+}


### PR DESCRIPTION
## Summary

1. Upgrade to latest Greenwood - https://github.com/ProjectEvergreen/greenwood/issues/1414
1. Add "admin" route for testing / validating `request.json()` usage

## TODO
1. [x] Verify `request.json` works as expected on Vercel - https://github.com/ProjectEvergreen/greenwood/issues/1460
1. [ ] (nice to have) Nested API routes (and SSR pages?) not working? - https://github.com/ProjectEvergreen/greenwood-demo-adapter-vercel/pull/34
1. [x] README updates (Admin / webhook page)